### PR TITLE
basement module AndroidManifest package name

### DIFF
--- a/basement/src/main/AndroidManifest.xml
+++ b/basement/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.computerrock.location">
+    package="com.computerrock.basement">
 
 </manifest>


### PR DESCRIPTION
Fixed AndroidManifest package name for 'basement' module. It was the same as in 'location' module, which was causing duplicate BuildConfig class to be generated, which crashes build